### PR TITLE
feat: add velocity limit

### DIFF
--- a/lsdb_can_interface/include/lsdb_can_interface/lsdb_can_interface.hpp
+++ b/lsdb_can_interface/include/lsdb_can_interface/lsdb_can_interface.hpp
@@ -37,6 +37,7 @@ private:
     Start,                      // 初期状態
     Setting_trapezoidal_accel,  // 台形加速度設定中
     Setting_trapezoidal_decel,  // 台形減速度設定中
+    Setting_max_rpm_limit,      // 上限RPM設定中
     Setting_action_mode,        // 動作モード設定中
     Setting_motor_operation,    // モーター動作設定中
     Setting_pdo_function,       // PDO function設定中
@@ -50,6 +51,7 @@ private:
   uint32_t pdo_fnc_can_id_;
   uint32_t trapezoidal_accel_;  // accel
   uint32_t trapezoidal_decel_;  // decel
+  uint16_t max_rpm_limit_;
 
   // Variable
   lsdb_msgs::msg::LsdbStatusStamped lsdb_status_;

--- a/lsdb_can_interface/launch/lsdb_can_interface.launch.xml
+++ b/lsdb_can_interface/launch/lsdb_can_interface.launch.xml
@@ -8,7 +8,7 @@
   <arg name="node_id" default="1"/>
   <arg name="trapezoidal_accel" default="2.0"/>
   <arg name="trapezoidal_decel" default="2.0"/>
-  <arg name="max_rpm_limit" default="122" doc="speed limit setting on motor driver, unit is [rpm]"/>
+  <arg name="max_rpm_limit" default="122"/> <!-- When wheel_diameter = 260, then 122rpm ≒ 6km/h -->
   <arg name="status_loop_rate_hz" default="10.0"/>
 
   <node pkg="lsdb_can_interface" name="lsdb_can_interface" exec="lsdb_can_interface" output="log">

--- a/lsdb_can_interface/launch/lsdb_can_interface.launch.xml
+++ b/lsdb_can_interface/launch/lsdb_can_interface.launch.xml
@@ -8,6 +8,7 @@
   <arg name="node_id" default="1"/>
   <arg name="trapezoidal_accel" default="2.0"/>
   <arg name="trapezoidal_decel" default="2.0"/>
+  <arg name="max_rpm_limit" default="122" doc="speed limit setting on motor driver, unit is [rpm]"/>
   <arg name="status_loop_rate_hz" default="10.0"/>
 
   <node pkg="lsdb_can_interface" name="lsdb_can_interface" exec="lsdb_can_interface" output="log">
@@ -18,6 +19,7 @@
     <param name="node_id" value="$(var node_id)"/>
     <param name="trapezoidal_accel" value="$(var trapezoidal_accel)"/>
     <param name="trapezoidal_decel" value="$(var trapezoidal_decel)"/>
+    <param name="max_rpm_limit" value="$(var max_rpm_limit)"/>
     <param name="status_loop_rate_hz" value="$(var status_loop_rate_hz)"/>
   </node>
 

--- a/lsdb_can_interface/src/lsdb_can_interface.cpp
+++ b/lsdb_can_interface/src/lsdb_can_interface.cpp
@@ -31,6 +31,7 @@ LsdbCanInterface::LsdbCanInterface(const rclcpp::NodeOptions & node_options)
   trapezoidal_accel_ = (uint32_t)(trapezoidal_accel * 256.0 * 4096.0 / 15625.0);
   trapezoidal_decel_ = (uint32_t)(trapezoidal_decel * 256.0 * 4096.0 / 15625.0);
 
+  max_rpm_limit_ = declare_parameter<int>("max_rpm_limit", 122);  // If wheel_diameter = 260, then 122rpm ≒ 6km/h
   const double status_loop_rate_hz = declare_parameter<double>("status_loop_rate_hz", 10.0);
 
   // Subscriber
@@ -84,11 +85,20 @@ void LsdbCanInterface::lsdbInitialization(const uint32_t can_cmd_id, const bool 
       break;
   case InitStatus::Setting_trapezoidal_decel:
       if (can_cmd_id == spec_map[CommandID::eTrapezoidal_deceleration].can_cmd_id && is_write_success) {
-        sendCommand(CommandID::eAction_mode, (int8_t)0x03, ComType::write);
-        initialize_status_ = InitStatus::Setting_action_mode;
+        sendCommand(CommandID::eMaximum_speed_limit_rpm, max_rpm_limit_, ComType::write);
+        initialize_status_ = InitStatus::Setting_max_rpm_limit;
       } else {
         sendCommand(CommandID::eTrapezoidal_deceleration, trapezoidal_decel_, ComType::write);
         RCLCPP_ERROR_STREAM(this->get_logger(), "[lsdbInitialization] Write commnad failed: trapezoidal_decel");
+      }
+      break;
+  case InitStatus::Setting_max_rpm_limit:
+      if (can_cmd_id == spec_map[CommandID::eMaximum_speed_limit_rpm].can_cmd_id && is_write_success) {
+        sendCommand(CommandID::eAction_mode, (int8_t)0x03, ComType::write);
+        initialize_status_ = InitStatus::Setting_action_mode;
+      } else {
+        sendCommand(CommandID::eMaximum_speed_limit_rpm, max_rpm_limit_, ComType::write);
+        RCLCPP_ERROR_STREAM(this->get_logger(), "[lsdbInitialization] Write commnad failed: max_rpm_limit");
       }
       break;
   case InitStatus::Setting_action_mode:

--- a/lsdb_interface/include/lsdb_interface/lsdb_interface.hpp
+++ b/lsdb_interface/include/lsdb_interface/lsdb_interface.hpp
@@ -53,6 +53,7 @@ private:
   double speed_scale_factor_;
   double loop_rate_;
   double control_cmd_timeout_sec_;
+  double vehicle_velocity_limit_;
   bool is_emergency_{false};
   rclcpp::Time prev_control_cmd_stamp_{0, 0, RCL_ROS_TIME};
   bool is_control_command_timeout_;

--- a/lsdb_interface/launch/lsdb_interface.launch.xml
+++ b/lsdb_interface/launch/lsdb_interface.launch.xml
@@ -82,7 +82,7 @@
     <!-- autoware interface -->
     <arg name="loop_rate" default="50.0"/>
     <arg name="control_cmd_timeout_sec" default="0.5"/>
-    <arg name="vehicle_velocity_limit" default="1.67" doc="velocity limit on vehicle interface, unit is [mps]. 1.67mps ≒ 6.0kmph"/>
+    <arg name="vehicle_velocity_limit" default="1.67"/> <!-- Velocity limit on vehicle interface, unit is [mps]. 1.67mps ≒ 6.0kmph -->
     <node pkg="lsdb_interface" name="lsdb_interface" exec="lsdb_interface" output="log">
       <param name="loop_rate" value="$(var loop_rate)"/>
       <param name="control_cmd_timeout_sec" value="$(var control_cmd_timeout_sec)"/>

--- a/lsdb_interface/launch/lsdb_interface.launch.xml
+++ b/lsdb_interface/launch/lsdb_interface.launch.xml
@@ -82,9 +82,11 @@
     <!-- autoware interface -->
     <arg name="loop_rate" default="50.0"/>
     <arg name="control_cmd_timeout_sec" default="0.5"/>
+    <arg name="vehicle_velocity_limit" default="1.67" doc="velocity limit on vehicle interface, unit is [mps]. 1.67mps ≒ 6.0kmph"/>
     <node pkg="lsdb_interface" name="lsdb_interface" exec="lsdb_interface" output="log">
       <param name="loop_rate" value="$(var loop_rate)"/>
       <param name="control_cmd_timeout_sec" value="$(var control_cmd_timeout_sec)"/>
+      <param name="vehicle_velocity_limit" value="$(var vehicle_velocity_limit)"/>
       <remap from="~/input/lsdb/left/status" to="lsdb/left/status"/>
       <remap from="~/input/lsdb/left/motor_status" to="lsdb/left/motor_status"/>
       <remap from="~/input/lsdb/right/status" to="lsdb/right/status"/>

--- a/lsdb_interface/src/lsdb_interface.cpp
+++ b/lsdb_interface/src/lsdb_interface.cpp
@@ -29,6 +29,7 @@ LsdbInterface::LsdbInterface(const rclcpp::NodeOptions & node_options)
   speed_scale_factor_ = declare_parameter<double>("speed_scale_factor", 1.0);
   loop_rate_ = declare_parameter<double>("loop_rate", 50.0);
   control_cmd_timeout_sec_ = declare_parameter<double>("control_cmd_timeout_sec", 1.0);
+  vehicle_velocity_limit_ = declare_parameter<double>("vehicle_velocity_limit", 1.67);
 
   // Subscribe from Autoware
   control_cmd_sub_ =
@@ -201,8 +202,12 @@ void LsdbInterface::onAckermannControlCmd(
   s1_left_cmd_.stamp = msg->stamp;
 
   double trans_vel = msg->longitudinal.speed;
-  double angular_vel =
-    msg->longitudinal.speed * std::tan(msg->lateral.steering_tire_angle) / wheel_base_;
+  if (trans_vel > vehicle_velocity_limit_) {
+    trans_vel = vehicle_velocity_limit_;
+    RCLCPP_ERROR_THROTTLE(
+          this->get_logger(), *get_clock(), 1000, "error: input command over the limit velocity(%f[m/s]), limit to %f[m/s]", msg->longitudinal.speed, vehicle_velocity_limit_);
+  }
+  double angular_vel = trans_vel * std::tan(msg->lateral.steering_tire_angle) / wheel_base_;
 
   double left_wheel_rpm = 0.0;
   double right_wheel_rpm = 0.0;


### PR DESCRIPTION
Add velocity limit and rpm limit for safety.
Confirmed on actual vehicle as below.

velocity limit = 0.4 m/s on vehicle interface
![image (1)](https://github.com/user-attachments/assets/7705153d-b174-4486-bfc2-2a1a102f39d3)

velocity limit = 30 rpm on motor driver settings
![image (2)](https://github.com/user-attachments/assets/0240788f-414e-4717-a9dd-7b450d9d2d9b)